### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Continued work on big projects<br>
 TOMMY CHEN<br>
 SCALE INVARIANT FEATURE TRANSFORM (SIFT)<br>
 SINGULAR VALUE DECOMPOSITION<br>
-RANDOM SAMPLE CONCENSUS (RANSAC)<br>
+RANDOM SAMPLE CONSENSUS (RANSAC)<br>
 https://www.youtube.com/watch?v=ATxU93BYWnA<br><br>
 
 <b>FRI 7/25/14</b><br>


### PR DESCRIPTION
@Benedict-Bolton, I've corrected a typographical error in the documentation of the [RumpusRoom](https://github.com/Benedict-Bolton/RumpusRoom) project. Specifically, I've changed concensus to consensus. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
